### PR TITLE
APM-9177: attempt a simple basic fix to avoid reading length from und…

### DIFF
--- a/src/generatePrefixesList.js
+++ b/src/generatePrefixesList.js
@@ -88,8 +88,8 @@ module.exports = function generatePrefixes(asnList, outputFile, exclude, exclude
         getMultipleOrigins(prefix)
             .then(asns => {
 
-                if (asns.length) {
-                    const origin = (asns && asns.length) ? asns : [asn];
+                const origin = (asns && asns.length) ? asns : [asn];
+                if (origin.length) {
 
                     for (let o of origin) {
                         allOrigins[o] = true;


### PR DESCRIPTION
- [x] fixed undefined length error
- [ ] fix new outstanding error after first fix
```
RIPEstat related-prefixes query failed: cannot retrieve information for 146.66.118.0/24
Cannot download more specific prefixes of 146.66.118.0/24 TypeError: Cannot read property 'map' of undefined
    at /snapshot/build/src/generatePrefixesList.js:227:34
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Promise.all (index 6)
```


### Addresses:
* [APM-9177](https://appneta.atlassian.net/browse/APM-9177)

### Related PR:
* https://github.com/appneta/bgp-collector/pull/139